### PR TITLE
fix deprecation warning (wp_richedit_pre)

### DIFF
--- a/acf-single_line_wysiwyg-v5.php
+++ b/acf-single_line_wysiwyg-v5.php
@@ -146,7 +146,15 @@ class acf_field_single_line_wysiwyg extends acf_field {
 		
 		// filter value for editor
 		remove_all_filters( 'acf_the_editor_content' );
-		add_filter('acf_the_editor_content', 'wp_richedit_pre');
+
+    // fix possible deprecation notice
+    global $wp_version;
+    if ( (float)$wp_version >= 4.3 ) {
+      add_filter('acf_the_editor_content', 'format_for_editor');
+    }
+    else {
+      add_filter('acf_the_editor_content', 'wp_richedit_pre');
+    }
 		
 		$field['value'] = apply_filters( 'acf_the_editor_content', $field['value'] );
 		


### PR DESCRIPTION
Just simple deprecation fix for WP 4.3+

Thanks for this plugin it is extremely useful for all subtitles and descriptions where single line and limited styling is required.
